### PR TITLE
기능변경 : 회원가입 요청 흐름 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,3 +89,4 @@ volumes:
 
 networks:
   network-sentinel:
+    name: network-sentinel

--- a/sentinel-app/Dockerfile
+++ b/sentinel-app/Dockerfile
@@ -1,6 +1,19 @@
-FROM eclipse-temurin:21-jdk
+FROM gradle:8.5-jdk21 AS build
+
 WORKDIR /app
-COPY build/libs/sentinel-server-0.0.1-SNAPSHOT.jar app.jar
+
+COPY . .
+
+RUN gradle clean build -x test --no-daemon --no-build-cache
+
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
 COPY .env .env
-RUN mkdir -p /var/log/app
+
+EXPOSE 8080
+
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/sentinel-app/build.gradle
+++ b/sentinel-app/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
+	implementation "org.springdoc:springdoc-openapi-starter-webflux-ui:2.3.0"
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/controller/AccountApi.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/controller/AccountApi.java
@@ -3,9 +3,7 @@ package xyz.samsami.sentinel_server.account.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 import xyz.samsami.sentinel_server.account.dto.AccountReqCreateDto;
@@ -13,19 +11,25 @@ import xyz.samsami.sentinel_server.account.dto.AccountReqLoginDto;
 import xyz.samsami.sentinel_server.account.dto.AccountRespCreateDto;
 import xyz.samsami.sentinel_server.common.dto.CommonRespDto;
 
-@RequestMapping("/api")
+@RequestMapping("/api/accounts")
 @Tag(name = "Account API", description = "계정 관련 API")
 public interface AccountApi {
 
     @Operation(summary = "계정 생성", description = "새로운 계정을 생성합니다.")
-    @PostMapping("/accounts")
+    @PostMapping
     Mono<CommonRespDto<AccountRespCreateDto>> createAccount(@RequestBody AccountReqCreateDto dto);
 
     @Operation(summary = "로그인", description = "계정 로그인 후 쿠키에 토큰을 저장합니다.")
-    @PostMapping("/tokens:login")
+    @PostMapping("/session")
     Mono<ResponseEntity<Void>> loginAccount(@RequestBody AccountReqLoginDto dto);
 
     @Operation(summary = "로그아웃", description = "계정 로그아웃 처리")
-    @PostMapping("/tokens:logout")
+    @DeleteMapping("/session")
     Mono<CommonRespDto<Void>> logoutAccount(ServerWebExchange exchange);
+
+    @Operation(summary = "로그인 상태 확인", description = "유효한 토큰인지 확인합니다.")
+    @GetMapping("/session")
+    default Mono<ResponseEntity<Void>> validateAccount(ServerWebExchange exchange) {
+        return Mono.just(ResponseEntity.ok().build());
+    }
 }

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/dispatcher/AccountPostProcessorDispatcher.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/dispatcher/AccountPostProcessorDispatcher.java
@@ -1,0 +1,27 @@
+package xyz.samsami.sentinel_server.account.dispatcher;
+
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import xyz.samsami.sentinel_server.account.domain.Account;
+import xyz.samsami.sentinel_server.account.dto.AccountReqCreateDto;
+import xyz.samsami.sentinel_server.account.processor.AccountPostProcessor;
+import xyz.samsami.sentinel_server.account.type.AccountType;
+
+import java.util.List;
+
+@Component
+public class AccountPostProcessorDispatcher {
+    private final List<AccountPostProcessor> processors;
+
+    public AccountPostProcessorDispatcher(List<AccountPostProcessor> processors) {
+        this.processors = processors;
+    }
+
+    public Mono<Void> process(AccountType type, Account account, AccountReqCreateDto dto) {
+        return processors.stream()
+            .filter(p -> p.supports(type))
+            .findFirst()
+            .map(p -> p.postProcess(account, dto))
+            .orElse(Mono.empty());
+    }
+}

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/dto/BlokeyLandReqDto.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/dto/BlokeyLandReqDto.java
@@ -4,17 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import xyz.samsami.sentinel_server.account.type.AccountType;
+
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class AccountReqCreateDto {
-    private String email;
-    private String password;
-    private AccountType type;
-
+public class BlokeyLandReqDto {
+    private UUID id;
     private String nickname;
     private String bio;
 }

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/processor/AccountPostProcessor.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/processor/AccountPostProcessor.java
@@ -1,0 +1,11 @@
+package xyz.samsami.sentinel_server.account.processor;
+
+import reactor.core.publisher.Mono;
+import xyz.samsami.sentinel_server.account.domain.Account;
+import xyz.samsami.sentinel_server.account.dto.AccountReqCreateDto;
+import xyz.samsami.sentinel_server.account.type.AccountType;
+
+public interface AccountPostProcessor {
+    boolean supports(AccountType type);
+    Mono<Void> postProcess(Account account, AccountReqCreateDto dto);
+}

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/processor/BlokeyLandPostProcessor.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/processor/BlokeyLandPostProcessor.java
@@ -1,0 +1,38 @@
+package xyz.samsami.sentinel_server.account.processor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import xyz.samsami.sentinel_server.account.domain.Account;
+import xyz.samsami.sentinel_server.account.dto.AccountReqCreateDto;
+import xyz.samsami.sentinel_server.account.dto.BlokeyLandReqDto;
+import xyz.samsami.sentinel_server.account.type.AccountType;
+
+@Component
+public class BlokeyLandPostProcessor implements AccountPostProcessor {
+    private final WebClient webClient;
+
+    public BlokeyLandPostProcessor(WebClient.Builder builder) {
+        this.webClient = builder.baseUrl("http://blokey-land:8081").build();
+    }
+
+    @Override
+    public boolean supports(AccountType type) {
+        return type == AccountType.BLOKEY_LAND;
+    }
+
+    @Override
+    public Mono<Void> postProcess(Account account, AccountReqCreateDto dto) {
+        BlokeyLandReqDto blokeyDto = BlokeyLandReqDto.builder()
+            .id(account.getId())
+            .nickname(dto.getNickname())
+            .bio(dto.getBio())
+            .build();
+
+        return webClient.post()
+            .uri("/api/blokeys")
+            .bodyValue(blokeyDto)
+            .retrieve()
+            .bodyToMono(Void.class);
+    }
+}

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/type/AccountType.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/type/AccountType.java
@@ -1,0 +1,12 @@
+package xyz.samsami.sentinel_server.account.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AccountType {
+    BLOKEY_LAND("프로젝트 관리 서비스");
+
+    private final String description;
+}

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/filter/JwtWebFilter.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/filter/JwtWebFilter.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
@@ -15,31 +16,52 @@ import xyz.samsami.sentinel_server.common.service.JwtService;
 import xyz.samsami.sentinel_server.common.type.CookieType;
 import xyz.samsami.sentinel_server.common.type.ExceptionType;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 public class JwtWebFilter implements WebFilter {
     private final JwtService service;
     private final JwtProvider provider;
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+    private static final List<String> EXCLUDE_PATHS = List.of(
+        "/api/accounts/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/v3/api-docs/**",
+        "/webjars/**"
+    );
 
     @NonNull
     @Override
     public Mono<Void> filter(@NonNull ServerWebExchange exchange, @NonNull WebFilterChain chain) {
+        String path = exchange.getRequest().getPath().value();
+
+        boolean excluded = EXCLUDE_PATHS.stream()
+            .anyMatch(pattern -> pathMatcher.match(pattern, path));
+
+        if (excluded) return chain.filter(exchange);
+
         String accessToken = provider.resolveToken(exchange, CookieType.ACCESS_TOKEN.getName());
         String refreshToken = provider.resolveToken(exchange, CookieType.REFRESH_TOKEN.getName());
 
-        if (accessToken == null) return service.reissueAccessTokenAndProceed(exchange, chain, refreshToken);
+        if (accessToken == null) {
+            if (refreshToken == null) return Mono.error(new CommonException(ExceptionType.UNAUTHORIZED, "로그인이 필요합니다."));
+            return service.reissueAccessTokenAndProceed(exchange, chain, refreshToken);
+        }
+
+        if (!provider.validateToken(accessToken)) {
+            return service.reissueAccessTokenAndProceed(exchange, chain, refreshToken);
+        }
 
         return service.isTokenBlacklisted(accessToken)
             .flatMap(isBlacklisted -> {
                 if (isBlacklisted) return Mono.error(new CommonException(ExceptionType.FORBIDDEN, "권한이 없습니다."));
 
-                if (provider.validateToken(accessToken)) {
-                    Authentication authentication = provider.getAuthentication(accessToken);
-                    return chain.filter(exchange)
-                        .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
-                }
-
-                return service.reissueAccessTokenAndProceed(exchange, chain, refreshToken);
+                Authentication authentication = provider.getAuthentication(accessToken);
+                return chain.filter(exchange)
+                    .contextWrite(ReactiveSecurityContextHolder.withAuthentication(authentication));
             });
     }
 }

--- a/sentinel-app/src/main/resources/application.yml
+++ b/sentinel-app/src/main/resources/application.yml
@@ -23,6 +23,19 @@ spring:
             - Path=/blokey-land/**
           filters:
             - RewritePath=/blokey-land/(?<remaining>.*), /${remaining}
+      globalcors:
+        add-to-simple-url-handler-mapping: true
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins: ${CLOUD_GATEWAY_GLOBALCORS_ALLOWED_ORIGINS}
+            allowedMethods:
+              - GET
+              - POST
+              - PUT
+              - DELETE
+              - OPTIONS
+            allowedHeaders: "*"
+            allowCredentials: true
 
 jwt:
   secret-key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📝 설명
<!-- 어떤 작업을 했는지 간략히 설명해주세요 -->

- 회원가입 요청 흐름 변경

---

## ✅ 체크리스트
<!-- 코드가 정상적으로 작동하는지 확인함 -->

- [x] 로그인 상태 확인 API 개발
- [x] 회원 저장 후 특정 서비스의 사용자 데이터 저장 API 호출
- [x] Spring-cloud-gateway CORS 설정
- [x] Dockerfile 수정
- [x] JWT 필터 로직 변경

---

## 📂 관련 이슈
<!-- 이 PR이 관련된 이슈 번호를 연결해주세요 (예: Closes #42) -->

Closes #4 

---

## 📌 기타 참고사항
<!-- 코드 리뷰어가 참고하면 좋을 만한 내용을 추가해주세요 -->
### 기존 로직
1. [클라이언트] 클라이언트가 게이트웨이로 특정 서비스에 회원가입 요청
2. [게이트웨이] 게이트웨이에서 특정 서비스로 프록싱
3. [특정 서비스] 특정 서비스에서 게이트웨이로 회원가입 요청
4. [게이트웨이] 회원가입 처리 및 매핑을 위한 계정 UUID 응답
5. [특정 서비스] 응답 받은 UUID와 함께 서비스별 사용자 메타 데이터를 함께 저장

### 기존 로직의 문제점
- 각 서비스에서 역으로 게이트웨이 API를 호출하는 것은 구조 상 적절하지 않음
- `CORS`나 `Spring Security` 필터 등 유지보수 복잡함

### 개선 로직
1. [클라이언트] 클라이언트가 게이트웨이로 특정 서비스에 회원가입 요청
2. [게이트웨이] 게이트웨이에서 회원가입 처리 및 서비스별 사용자 메타 데이터 저장을 위해 특정 서비스 `API` 호출
3. [특정 서비스] 게이트웨이에서 `UUID`와 사용자 메타 데이터를 기반으로 사용자 데이터 저장