### PR TITLE
기능추가 : 받은 요청에 Account UUID를 담은 X-Account-Id 헤더 포함

### DIFF
--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/service/AccountService.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/account/service/AccountService.java
@@ -50,13 +50,13 @@ public class AccountService {
 
     public Mono<AccountRespLoginDto> loginAccount(AccountReqLoginDto dto) {
         return repository.findByEmail(dto.getEmail())
-            .switchIfEmpty(Mono.error(new CommonException(ExceptionType.UNAUTHORIZED, "가입된 이메일이 없습니다.")))
+            .switchIfEmpty(Mono.error(new CommonException(ExceptionType.NOT_FOUND, "가입된 이메일이 없습니다.")))
             .flatMap(account -> {
                 if (!passwordEncoder.matches(dto.getPassword(), account.getPassword())) {
                     return Mono.error(new CommonException(ExceptionType.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."));
                 }
 
-                return jwtService.login(account.getEmail())
+                return jwtService.login(account.getEmail(), account.getId())
                     .map(tokenResponse -> new AccountRespLoginDto(
                         tokenResponse.getAccessToken(),
                         tokenResponse.getRefreshToken()

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/config/CorsConfig.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/config/CorsConfig.java
@@ -2,6 +2,7 @@ package xyz.samsami.sentinel_server.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.reactive.CorsWebFilter;
 import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
@@ -11,10 +12,11 @@ import java.util.List;
 @Configuration
 public class CorsConfig {
     @Bean
+    @Order(-1)
     public CorsWebFilter corsWebFilter() {
         CorsConfiguration corsConfig = new CorsConfiguration();
         corsConfig.setAllowedOriginPatterns(List.of("http://localhost:3000"));
-        corsConfig.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        corsConfig.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         corsConfig.setAllowedHeaders(List.of("*"));
         corsConfig.setAllowCredentials(true);
 

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/config/SecurityConfig.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                 )
             .authorizeExchange(exchange -> exchange
                 .pathMatchers(HttpMethod.OPTIONS).permitAll()
+                .pathMatchers(HttpMethod.GET, "/api/accounts/session").authenticated()
                 .pathMatchers(
                     "/api/accounts/**",
                     "/swagger-ui/**",

--- a/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/filter/JwtSubjectHeaderFilter.java
+++ b/sentinel-app/src/main/java/xyz/samsami/sentinel_server/common/filter/JwtSubjectHeaderFilter.java
@@ -1,0 +1,46 @@
+package xyz.samsami.sentinel_server.common.filter;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public class JwtSubjectHeaderFilter implements GlobalFilter, Ordered {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        String accessToken = null;
+
+        HttpCookie cookie = exchange.getRequest().getCookies().getFirst("access_token");
+        if (cookie != null) accessToken = cookie.getValue();
+
+        if (accessToken != null) {
+            try {
+                JWTClaimsSet claims = JWTParser.parse(accessToken).getJWTClaimsSet();
+                String subject = claims.getSubject();
+
+                ServerWebExchange mutatedExchange = exchange.mutate()
+                    .request(r ->
+                        r.headers(headers ->
+                            headers.add("X-Account-Id", subject)))
+                    .build();
+
+                return chain.filter(mutatedExchange);
+            } catch (Exception e) {
+                /* 아무 처리하지 않음 */
+            }
+        }
+
+        return chain.filter(exchange);
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/sentinel-app/src/main/resources/application.yml
+++ b/sentinel-app/src/main/resources/application.yml
@@ -23,19 +23,5 @@ spring:
             - Path=/blokey-land/**
           filters:
             - RewritePath=/blokey-land/(?<remaining>.*), /${remaining}
-      globalcors:
-        add-to-simple-url-handler-mapping: true
-        corsConfigurations:
-          '[/**]':
-            allowedOrigins: ${CLOUD_GATEWAY_GLOBALCORS_ALLOWED_ORIGINS}
-            allowedMethods:
-              - GET
-              - POST
-              - PUT
-              - DELETE
-              - OPTIONS
-            allowedHeaders: "*"
-            allowCredentials: true
-
 jwt:
   secret-key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📝 설명
<!-- 어떤 작업을 했는지 간략히 설명해주세요 -->

- 받은 요청에 `Account UUID`를 담은 `X-Account-Id` 헤더 포함

---

## ✅ 체크리스트
<!-- 코드가 정상적으로 작동하는지 확인함 -->

- [x] 받은 요청에 `Account UUID`를 담은 `X-Account-Id` 헤더 포함
- [x] `CORS` 처리 중복 제거

---

## 📂 관련 이슈
<!-- 이 PR이 관련된 이슈 번호를 연결해주세요 (예: Closes #42) -->

Closes #6 

---

## 📌 기타 참고사항
<!-- 코드 리뷰어가 참고하면 좋을 만한 내용을 추가해주세요 -->

- 기타사항 없음